### PR TITLE
Player damage in config, entity type check

### DIFF
--- a/src/main/java/io/github/communityminecraftplugin/communityminecraftplugin/configuration/Settings.java
+++ b/src/main/java/io/github/communityminecraftplugin/communityminecraftplugin/configuration/Settings.java
@@ -20,7 +20,8 @@ public enum Settings {
 	 * Welcome message.
 	 * @return {@link String}
 	 */
-	MESSAGES_WELCOME ("messages.welcome", "&7Welcome &a%player&7! Enjoy this plugin coded during &f#Hacktoberfest&7!");
+	MESSAGES_WELCOME ("messages.welcome", "&7Welcome &a%player&7! Enjoy this plugin coded during &f#Hacktoberfest&7!"),
+        GENERAL_PLAYER_DAMAGE ("general.player_damage", true);
 	
 	/**
 	 * Quicker access to all the values stored in the configuration.

--- a/src/main/java/io/github/communityminecraftplugin/communityminecraftplugin/listener/DamageListener.java
+++ b/src/main/java/io/github/communityminecraftplugin/communityminecraftplugin/listener/DamageListener.java
@@ -1,5 +1,7 @@
 package io.github.communityminecraftplugin.communityminecraftplugin.listener;
 
+import io.github.communityminecraftplugin.communityminecraftplugin.configuration.Settings;
+import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
@@ -13,7 +15,9 @@ public class DamageListener implements Listener{
      */
     @EventHandler
     public void onDamage(EntityDamageEvent event){
-        event.setCancelled(true);
+        if (event.getEntityType() == EntityType.PLAYER && !Settings.GENERAL_PLAYER_DAMAGE.getBoolean()) {
+            event.setCancelled(true);
+        }
     }
 
 }


### PR DESCRIPTION
Added "general" section in config along with "player_damage" section that defines whether the player will receive damage or not. Also added the entity type check in damage listener to catch only players